### PR TITLE
ci: build the library first

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -32,7 +32,8 @@ jobs:
         run: pnpm install
 
       # Build the library first
-      - run: pnpm run --filter react-live-unplugin build
+      - name: Build react-live-unplugin library
+        run: pnpm run --filter react-live-unplugin build
       - run: pnpm run --filter docs build
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -30,6 +30,9 @@ jobs:
             ${{ runner.os }}-pnpm-store-
       - name: Install dependencies
         run: pnpm install
+
+      # Build the library first
+      - run: pnpm run --filter react-live-unplugin build
       - run: pnpm run --filter docs build
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,1 +1,7 @@
 /// <reference types="@repo/dts/common" />
+
+declare namespace NodeJS {
+  interface ProcessEnv {
+    TYPE?: string;
+  }
+}


### PR DESCRIPTION
To fix CI build fail issue https://github.com/VdustR/react-live-unplugin/actions/runs/14954567257/job/42008503194#step:8:46

# Copilot

This pull request introduces a change to the GitHub Actions workflow for deploying documentation. The most notable update ensures that the `react-live-unplugin` library is built before the documentation is built and deployed.

### Workflow improvements:
* [`.github/workflows/gh-pages.yml`](diffhunk://#diff-c04119feaeffc2c216f069aec66797f2f839a2074287060698e3a2440dec8d45R33-R35): Added a step to build the `react-live-unplugin` library (`pnpm run --filter react-live-unplugin build`) before running the documentation build step.